### PR TITLE
FINI-887: IContent.GetDateTime() extension method.

### DIFF
--- a/Lombiq.HelpfulLibraries/Libraries/Contents/ContentExtensions.cs
+++ b/Lombiq.HelpfulLibraries/Libraries/Contents/ContentExtensions.cs
@@ -159,7 +159,7 @@ namespace OrchardCore.ContentManagement
         ///     </item>
         /// </list>
         /// </returns>
-        public static DateTime GetDateTime(this IContent content) =>
+        public static DateTime GetDateTimeUtc(this IContent content) =>
             content.ContentItem.ModifiedUtc ??
             content.ContentItem.PublishedUtc ??
             content.ContentItem.CreatedUtc ??

--- a/Lombiq.HelpfulLibraries/Libraries/Contents/ContentExtensions.cs
+++ b/Lombiq.HelpfulLibraries/Libraries/Contents/ContentExtensions.cs
@@ -138,5 +138,31 @@ namespace OrchardCore.ContentManagement
             $"DisplayText: {content.ContentItem.DisplayText}, " +
             $"ID: {content.ContentItem.ContentItemId}, " +
             $"Version ID: {content.ContentItem.ContentItemVersionId}";
+
+        /// <summary>
+        /// Returns the most relevant date of the <paramref name="content"/>'s <see cref="ContentItem"/>.
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// The values are resolved in the following order if available. If all of them are <see langword="null"/> then
+        /// <see cref="DateTime.MinValue"/> is returned.
+        /// </para>
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description><see cref="ContentItem.ModifiedUtc"/></description>
+        ///     </item>
+        ///     <item>
+        ///         <description><see cref="ContentItem.PublishedUtc"/></description>
+        ///     </item>
+        ///     <item>
+        ///         <description><see cref="ContentItem.CreatedUtc"/></description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        public static DateTime GetDateTime(this IContent content) =>
+            content.ContentItem.ModifiedUtc ??
+            content.ContentItem.PublishedUtc ??
+            content.ContentItem.CreatedUtc ??
+            DateTime.MinValue;
     }
 }


### PR DESCRIPTION
[FINI-887](https://lombiq.atlassian.net/browse/FINI-887)