### PR TITLE
OSOE-76: Removing unneeded Microsoft.VisualStudio.Threading reference that causes the analyzer to be applied in every consumer project

### DIFF
--- a/Lombiq.HelpfulLibraries/Lombiq.HelpfulLibraries.csproj
+++ b/Lombiq.HelpfulLibraries/Lombiq.HelpfulLibraries.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00014" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
     <PackageReference Include="MimeTypes" Version="2.1.1" />
     <PackageReference Include="Moq.AutoMock" Version="2.3.0" />
     <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.2.2" />


### PR DESCRIPTION
OSOE-76