### PR TITLE
OSOE-474: The existing field's DisplayName gets overwritten for no reason. in Lombiq.HelpfulLibraries

### DIFF
--- a/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentPartDefinitionBuilderExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentPartDefinitionBuilderExtensions.cs
@@ -47,13 +47,15 @@ public class ContentPartDefinitionBuilder<TPart>
             name,
             field =>
             {
-                field = field.MergeSettings<ContentPartFieldSettings>(x =>
-                {
-                    if (string.IsNullOrEmpty(x.DisplayName))
+                field = field.MergeSettings<ContentPartFieldSettings>(
+                    settings =>
                     {
-                        x.DisplayName = name;
-                    }
-                }).OfType(typeof(TField).Name);
+                        if (string.IsNullOrEmpty(settings.DisplayName))
+                        {
+                            settings.DisplayName = name;
+                        }
+                    })
+                    .OfType(typeof(TField).Name);
                 configuration?.Invoke(field);
             });
         return this;

--- a/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentPartDefinitionBuilderExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentPartDefinitionBuilderExtensions.cs
@@ -47,10 +47,15 @@ public class ContentPartDefinitionBuilder<TPart>
             name,
             field =>
             {
-                field = field.WithDisplayName(name).OfType(typeof(TField).Name);
+                field = field.MergeSettings<ContentPartFieldSettings>(x =>
+                {
+                    if (string.IsNullOrEmpty(x.DisplayName))
+                    {
+                        x.DisplayName = name;
+                    }
+                }).OfType(typeof(TField).Name);
                 configuration?.Invoke(field);
             });
-
         return this;
     }
 }


### PR DESCRIPTION
[OSOE-474](https://lombiq.atlassian.net/browse/OSOE-474)

[OSOE-474]: https://lombiq.atlassian.net/browse/OSOE-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Fixes #167 