### PR TITLE
OSOE-657: Retrive the Admin prefix from `AdminOptions.AdminUrlPrefix` instead of hardcoding it

### DIFF
--- a/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentHttpContextExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentHttpContextExtensions.cs
@@ -62,11 +62,10 @@ public static class ContentHttpContextExtensions
         params (string Key, object Value)[] additionalArguments)
         where TController : ControllerBase
     {
-        var provider = httpContext.RequestServices.GetService<ITypeFeatureProvider>();
         var route = TypedRoute.CreateFromExpression(
             actionExpression,
             additionalArguments,
-            provider);
+            httpContext.RequestServices);
         return route.ToString(httpContext);
     }
 

--- a/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentHttpContextExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Contents/ContentHttpContextExtensions.cs
@@ -1,8 +1,6 @@
 using Lombiq.HelpfulLibraries.OrchardCore.Mvc;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
-using OrchardCore.Environment.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/Lombiq.HelpfulLibraries.OrchardCore/Mvc/TypedRoute.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Mvc/TypedRoute.cs
@@ -164,7 +164,7 @@ public class TypedRoute
     /// <param name="additionalArguments">Additional arguments to add to the route and the key in the cache.</param>
     public static TypedRoute CreateFromExpression<TController>(
         Expression<Action<TController>> action,
-        IEnumerable<KeyValuePair<string, string>> additionalArguments,
+        IEnumerable<KeyValuePair<string, string>> additionalArguments = null,
         IServiceProvider serviceProvider = null)
         where TController : ControllerBase
     {
@@ -183,7 +183,7 @@ public class TypedRoute
                 methodParameters[index].Name,
                 ValueToString(Expression.Lambda(argument).Compile().DynamicInvoke())))
             .Where(pair => pair.Value != null)
-            .Concat(additionalArguments)
+            .Concat(additionalArguments ?? Enumerable.Empty<KeyValuePair<string, string>>())
             .ToList();
 
         var key = string.Join(

--- a/Lombiq.HelpfulLibraries.OrchardCore/Mvc/TypedRoute.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Mvc/TypedRoute.cs
@@ -30,10 +30,10 @@ public class TypedRoute
     private readonly Lazy<bool> _isAdminLazy;
     private readonly Lazy<string> _routeLazy;
 
-    public TypedRoute(
+    private TypedRoute(
         MethodInfo action,
         IEnumerable<KeyValuePair<string, string>> arguments,
-        ITypeFeatureProvider typeFeatureProvider = null)
+        IServiceProvider serviceProvider = null)
     {
         if (action?.DeclaringType is not { } controller)
         {
@@ -53,6 +53,7 @@ public class TypedRoute
         }
         else
         {
+            var typeFeatureProvider = serviceProvider?.GetService<ITypeFeatureProvider>();
             _area = typeFeatureProvider?.GetFeatureForDependency(controller).Extension.Id ??
                     controller.Assembly.GetCustomAttribute<ModuleNameAttribute>()?.Name ??
                     controller.Assembly.GetCustomAttribute<ModuleMarkerAttribute>()?.Name ??
@@ -144,12 +145,12 @@ public class TypedRoute
     public static TypedRoute CreateFromExpression<TController>(
         Expression<Action<TController>> actionExpression,
         IEnumerable<(string Key, object Value)> additionalArguments,
-        ITypeFeatureProvider typeFeatureProvider = null)
+        IServiceProvider serviceProvider = null)
         where TController : ControllerBase =>
         CreateFromExpression(
             actionExpression,
             additionalArguments.Select((key, value) => new KeyValuePair<string, string>(key, value.ToString())),
-            typeFeatureProvider);
+            serviceProvider);
 
     /// <summary>
     /// Creates and returns a new <see cref="TypedRoute"/> using the provided <paramref name="action"/> expression,
@@ -160,7 +161,7 @@ public class TypedRoute
     public static TypedRoute CreateFromExpression<TController>(
         Expression<Action<TController>> action,
         IEnumerable<KeyValuePair<string, string>> additionalArguments,
-        ITypeFeatureProvider typeFeatureProvider = null)
+        IServiceProvider serviceProvider = null)
         where TController : ControllerBase
     {
         Expression actionExpression = action;
@@ -192,7 +193,7 @@ public class TypedRoute
             _ => new TypedRoute(
                 operation.Method,
                 arguments,
-                typeFeatureProvider));
+                serviceProvider));
     }
 
     private static string ValueToString(object value) =>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Navigation/NavigationItemBuilderExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Navigation/NavigationItemBuilderExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using Lombiq.HelpfulLibraries.OrchardCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
-using OrchardCore.Environment.Extensions;
 using OrchardCore.Navigation;
 using System;
 using System.Linq.Expressions;

--- a/Lombiq.HelpfulLibraries.OrchardCore/Navigation/NavigationItemBuilderExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Navigation/NavigationItemBuilderExtensions.cs
@@ -34,11 +34,10 @@ public static class NavigationItemBuilderExtensions
         params (string Key, object Value)[] additionalArguments)
         where TContext : ControllerBase
     {
-        var provider = httpContext.RequestServices.GetService<ITypeFeatureProvider>();
         var route = TypedRoute.CreateFromExpression(
             actionExpression,
             additionalArguments,
-            provider);
+            httpContext.RequestServices);
 
         return builder.Action(route);
     }

--- a/Lombiq.HelpfulLibraries.Tests/UnitTests/Models/TypedRouteTests.cs
+++ b/Lombiq.HelpfulLibraries.Tests/UnitTests/Models/TypedRouteTests.cs
@@ -50,6 +50,8 @@ public class TypedRouteTests
         typeFeatureProvider.TryAdd(typeof(RouteTestController), new FeatureInfo(feature, new ExtensionInfo(feature)));
         services.AddSingleton<ITypeFeatureProvider>(typeFeatureProvider);
 
+        services.AddMemoryCache();
+
         configure?.Invoke(services);
 
         return services.BuildServiceProvider();

--- a/Lombiq.HelpfulLibraries.Tests/UnitTests/Models/TypedRouteTests.cs
+++ b/Lombiq.HelpfulLibraries.Tests/UnitTests/Models/TypedRouteTests.cs
@@ -1,5 +1,6 @@
 using Lombiq.HelpfulLibraries.OrchardCore.Mvc;
 using Lombiq.HelpfulLibraries.Tests.Controllers;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Extensions.Features;
 using Shouldly;
@@ -20,13 +21,23 @@ public class TypedRouteTests
         (string Name, object Value)[] additional,
         string tenantName)
     {
-        const string id = "Lombiq.HelpfulLibraries.Tests";
-
-        var typeFeatureProvider = new TypeFeatureProvider();
-        typeFeatureProvider.TryAdd(typeof(RouteTestController), new FeatureInfo(id, new ExtensionInfo(id)));
-
-        var route = TypedRoute.CreateFromExpression(actionExpression, additional, typeFeatureProvider);
+        var route = TypedRoute.CreateFromExpression(
+            actionExpression,
+            additional,
+            CreateServiceProvider());
         route.ToString(tenantName).ShouldBe(expected);
+    }
+
+    private static IServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+
+        const string feature = "Lombiq.HelpfulLibraries.Tests";
+        var typeFeatureProvider = new TypeFeatureProvider();
+        typeFeatureProvider.TryAdd(typeof(RouteTestController), new FeatureInfo(feature, new ExtensionInfo(feature)));
+        services.AddSingleton<ITypeFeatureProvider>(typeFeatureProvider);
+
+        return services.BuildServiceProvider();
     }
 
     public static IEnumerable<object[]> TypedRouteShouldWorkCorrectlyData()


### PR DESCRIPTION
[OSOE-657](https://lombiq.atlassian.net/browse/OSOE-657)
Fixes #209

[OSOE-657]: https://lombiq.atlassian.net/browse/OSOE-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ