### PR TITLE
LMBQ-213: Changing default distributed locking implementation to a local one

### DIFF
--- a/Libraries/Tasks/Locking/FileLock.cs
+++ b/Libraries/Tasks/Locking/FileLock.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.IO;
 using Orchard.Environment.Extensions;
-using Orchard.FileSystems.Media;
 using Orchard.Exceptions;
+using Orchard.FileSystems.Media;
 
 namespace Piedone.HelpfulLibraries.Tasks.Locking
 {
-    [OrchardFeature("Piedone.HelpfulLibraries.Tasks.Locking")]
+    [OrchardFeature("Piedone.HelpfulLibraries.Tasks.Locking.File")]
     public class FileLock : IDistributedLock
     {
         private readonly IStorageProvider _storageProvider;

--- a/Libraries/Tasks/Locking/LockFileCleaner.cs
+++ b/Libraries/Tasks/Locking/LockFileCleaner.cs
@@ -2,11 +2,10 @@
 using Orchard.Environment.Extensions;
 using Orchard.FileSystems.Media;
 using Orchard.Services;
-using Orchard.Tasks.Scheduling;
 
 namespace Piedone.HelpfulLibraries.Tasks.Locking
 {
-    [OrchardFeature("Piedone.HelpfulLibraries.Tasks.Locking")]
+    [OrchardFeature("Piedone.HelpfulLibraries.Tasks.Locking.File")]
     public class LockFileCleaner : IOrchardShellEvents
     {
         private readonly IClock _clock;

--- a/Libraries/Tasks/Locking/ObjectLock.cs
+++ b/Libraries/Tasks/Locking/ObjectLock.cs
@@ -1,0 +1,28 @@
+﻿using Orchard.Environment.Extensions;
+using Piedone.HelpfulLibraries.Tasks.Locking;
+
+namespace Piedone.HelpfulLibraries.Libraries.Tasks.Locking
+{
+    [OrchardFeature("Piedone.HelpfulLibraries.Tasks.Locking")]
+    public class ObjectLock : IDistributedLock
+    {
+        private readonly IObjectLockHolder _objectLockHolder;
+
+        private string _name;
+
+
+        public ObjectLock(IObjectLockHolder objectLockHolder) => _objectLockHolder = objectLockHolder;
+
+
+        public bool TryAcquire(string name)
+        {
+            _name = name;
+            return _objectLockHolder.TryAcquire(name);
+        }
+
+        public void Dispose()
+        {
+            if (!string.IsNullOrEmpty(_name)) _objectLockHolder.Release(_name);
+        }
+    }
+}

--- a/Libraries/Tasks/Locking/ObjectLockHolder.cs
+++ b/Libraries/Tasks/Locking/ObjectLockHolder.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Concurrent;
+using Orchard;
+using Orchard.Environment.Extensions;
+
+namespace Piedone.HelpfulLibraries.Libraries.Tasks.Locking
+{
+    public interface IObjectLockHolder : ISingletonDependency
+    {
+        bool TryAcquire(string name);
+        void Release(string name);
+    }
+
+
+    [OrchardFeature("Piedone.HelpfulLibraries.Tasks.Locking")]
+    public class ObjectLockHolder : IObjectLockHolder
+    {
+        private readonly object _dictionaryLock = new object();
+        private ConcurrentDictionary<string, bool> _locks = new ConcurrentDictionary<string, bool>();
+
+
+        public bool TryAcquire(string name)
+        {
+            lock (_dictionaryLock)
+            {
+                return _locks.TryAdd(name, true);
+            }
+        }
+
+        public void Release(string name)
+        {
+            lock (_dictionaryLock)
+            {
+                _locks.TryRemove(name, out _);
+            }
+        }
+    }
+}

--- a/Libraries/Tasks/Locking/ObjectLockHolder.cs
+++ b/Libraries/Tasks/Locking/ObjectLockHolder.cs
@@ -15,7 +15,7 @@ namespace Piedone.HelpfulLibraries.Libraries.Tasks.Locking
     public class ObjectLockHolder : IObjectLockHolder
     {
         private readonly object _dictionaryLock = new object();
-        private ConcurrentDictionary<string, bool> _locks = new ConcurrentDictionary<string, bool>();
+        private readonly ConcurrentDictionary<string, bool> _locks = new ConcurrentDictionary<string, bool>();
 
 
         public bool TryAcquire(string name)

--- a/Module.txt
+++ b/Module.txt
@@ -46,12 +46,17 @@ Features:
 		Dependencies: Piedone.HelpfulLibraries, Piedone.HelpfulLibraries.DependencyInjection
 	Piedone.HelpfulLibraries.Tasks.Locking:
 		Name: Tasks Libraries: Locking - Helpful Libraries
-		Description: Distributed locking services with file-based locking
+		Description: Distributed locking services foundations with a local default implementation.
 		Category: Developer
 		Dependencies: Piedone.HelpfulLibraries.Tasks
 	Piedone.HelpfulLibraries.Tasks.Locking.Database:
 		Name: Tasks Libraries: Database Locking - Helpful Libraries
 		Description: Distributed locking services with database-based locking
+		Category: Developer
+		Dependencies: Piedone.HelpfulLibraries.Tasks.Locking
+	Piedone.HelpfulLibraries.Tasks.Locking.File:
+		Name: Tasks Libraries: File Locking - Helpful Libraries
+		Description: Distributed locking services with Media file-based locking
 		Category: Developer
 		Dependencies: Piedone.HelpfulLibraries.Tasks.Locking
 	Piedone.HelpfulLibraries.Tasks.Jobs:

--- a/Piedone.HelpfulLibraries.csproj
+++ b/Piedone.HelpfulLibraries.csproj
@@ -253,6 +253,8 @@
     <Compile Include="Libraries\Tasks\Locking\FileLock.cs" />
     <Compile Include="Libraries\Tasks\Locking\DistributedLockManager.cs" />
     <Compile Include="Libraries\Tasks\Locking\LockRecordCleaner.cs" />
+    <Compile Include="Libraries\Tasks\Locking\ObjectLock.cs" />
+    <Compile Include="Libraries\Tasks\Locking\ObjectLockHolder.cs" />
     <Compile Include="Libraries\Tasks\ScheduledTaskManagerExtensions.cs" />
     <Compile Include="Libraries\Tasks\WellKnownConstants.cs" />
     <Compile Include="Libraries\Authentication\AuthenticationServiceExtensions.cs" />


### PR DESCRIPTION
Note that I created a new `dev-lombiq-tenants` branch so we don't have to update Lombiq Tenants to the latest `dev-orchard-1`.