### PR TITLE
OSOE-801: Fixing SQL Server auto-detection for linq2db queries and updating linq2db to v5.4.0

### DIFF
--- a/Lombiq.HelpfulLibraries.LinqToDb/LinqToDbQueryExecutor.cs
+++ b/Lombiq.HelpfulLibraries.LinqToDb/LinqToDbQueryExecutor.cs
@@ -75,10 +75,11 @@ public static class LinqToDbQueryExecutor
     private static string GetDatabaseProviderName(string dbName) =>
         dbName switch
         {
-            // Using explicit string instead of LinqToDB.ProviderName.SqlServer because if the "System.Data.SqlClient"
-            // provider will be used it will cause "Could not load type System.Data.SqlClient.SqlCommandBuilder"
-            // exception. See: https://github.com/linq2db/linq2db/issues/2191#issuecomment-618450439.
-            "SqlServer" => "Microsoft.Data.SqlClient",
+            // Using a concrete SQL Server version here removes the need for an initial auto-detection query that can
+            // fail, see https://github.com/Lombiq/Helpful-Libraries/issues/236. This needs to be the same version
+            // YesSql and thus OC supports. You can check it out in YesSql's build workflow:
+            // https://github.com/sebastienros/yessql/blob/main/.github/workflows/build.yml.
+            "SqlServer" => ProviderName.SqlServer2019,
             "Sqlite" => ProviderName.SQLite,
             "MySql" => ProviderName.MySql,
             "PostgreSql" => ProviderName.PostgreSQL,

--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="linq2db" Version="5.3.2" />
+    <PackageReference Include="linq2db" Version="5.4.0" />
     <PackageReference Include="OrchardCore.Data.YesSql" Version="1.8.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
[OSOE-801](https://lombiq.atlassian.net/browse/OSOE-801)
Fixes #236

[OSOE-801]: https://lombiq.atlassian.net/browse/OSOE-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ