### PR TITLE
OSOE-854: Fix new IDE0305 analyzer violation in `UseStrictAndSecureCookies()`

### DIFF
--- a/Lombiq.HelpfulLibraries.AspNetCore/Security/ApplicationBuilderExtensions.cs
+++ b/Lombiq.HelpfulLibraries.AspNetCore/Security/ApplicationBuilderExtensions.cs
@@ -159,7 +159,7 @@ public static class ApplicationBuilderExtensions
 
                 if (changed)
                 {
-                    context.Response.Headers[setCookieHeader] = new StringValues(newCookies.ToArray());
+                    context.Response.Headers[setCookieHeader] = new StringValues([.. newCookies]);
                 }
 
                 return Task.CompletedTask;


### PR DESCRIPTION
[OSOE-854](https://lombiq.atlassian.net/browse/OSOE-854)
Fixes #261

[OSOE-854]: https://lombiq.atlassian.net/browse/OSOE-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ