### PR TITLE
NEST-536: Liquid Parser Tag and ShapeTagHelperBase

### DIFF
--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,6 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="linq2db" Version="5.4.0" />
-    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18309" />
   </ItemGroup>
 </Project>

--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,6 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="linq2db" Version="5.4.0" />
-    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18312" />
   </ItemGroup>
 </Project>

--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,6 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="linq2db" Version="5.4.0" />
-    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18288" />
+    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18305" />
   </ItemGroup>
 </Project>

--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,6 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="linq2db" Version="5.4.0" />
-    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18313" />
   </ItemGroup>
 </Project>

--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,6 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="linq2db" Version="5.4.0" />
-    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Data.YesSql" Version="2.0.0-preview-18315" />
   </ItemGroup>
 </Project>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Docs/TagHelpers.md
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Docs/TagHelpers.md
@@ -3,3 +3,4 @@
 Make sure to use `services.AddTagHelpers<T>()` in the `Startup` class and `@addTagHelper *, Lombiq.HelpfulLibraries.OrchardCore` in the __ViewImports.cshtml_ file.
 
 - `EditorFieldSetTagHelper`: Eliminates significant boilerplate for editor fields in the admin dashboard. With this you can add `asp-for` to an empty `<fieldset>` element and skip the usual label, input, and validation elements that normally reside in them.
+- `ShapeTagHelperBase`: A base class for tag helpers that return a shape.

--- a/Lombiq.HelpfulLibraries.OrchardCore/Liquid/ILiquidParserTag.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Liquid/ILiquidParserTag.cs
@@ -1,5 +1,6 @@
 using Fluid;
 using Fluid.Ast;
+using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
@@ -8,7 +9,8 @@ using System.Threading.Tasks;
 namespace Lombiq.HelpfulLibraries.OrchardCore.Liquid;
 
 /// <summary>
-/// Describes a Liquid parser tag's parser and render methods.
+/// Describes a Liquid parser tag's renderer method. This is used in <see
+/// cref="LiquidServiceCollectionExtensions.AddLiquidParserTag{T}"/> to add a custom <c>{% tag_name %}</c> tag.
 /// </summary>
 public interface ILiquidParserTag
 {

--- a/Lombiq.HelpfulLibraries.OrchardCore/Liquid/ILiquidParserTag.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Liquid/ILiquidParserTag.cs
@@ -1,0 +1,23 @@
+using Fluid;
+using Fluid.Ast;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace Lombiq.HelpfulLibraries.OrchardCore.Liquid;
+
+/// <summary>
+/// Describes a Liquid parser tag's parser and render methods.
+/// </summary>
+public interface ILiquidParserTag
+{
+    /// <summary>
+    /// Renders the output of the parser tag.
+    /// </summary>
+    ValueTask<Completion> WriteToAsync(
+        IReadOnlyList<FilterArgument> argumentsList,
+        TextWriter writer,
+        TextEncoder encoder,
+        TemplateContext context);
+}

--- a/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
@@ -44,7 +44,6 @@ public static class LiquidServiceCollectionExtensions
     public static IServiceCollection AddLiquidParserTag<T>(this IServiceCollection services, string tagName)
             where T : class, ILiquidParserTag
     {
-        services.AddScoped<ILiquidParserTag, T>();
         services.AddKeyedScoped<ILiquidParserTag, T>(tagName);
 
         return services.Configure<LiquidViewOptions>(options =>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
@@ -49,7 +49,6 @@ public static class LiquidServiceCollectionExtensions
         services.AddKeyedScoped<ILiquidParserTag, T>(tagName);
 
         return services.Configure<LiquidViewOptions>(options =>
-        {
             options.LiquidViewParserConfiguration.Add(parser => parser.RegisterParserTag(
                 tagName,
                 parser.ArgumentsListParser,
@@ -58,7 +57,6 @@ public static class LiquidServiceCollectionExtensions
                     var provider = ((LiquidTemplateContext)context).Services;
                     var service = provider.GetKeyedService<ILiquidParserTag>(tagName);
                     return service.WriteToAsync(arguments, writer, encoder, context);
-                }));
-        });
+                })));
     }
 }

--- a/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
@@ -44,7 +44,6 @@ public static class LiquidServiceCollectionExtensions
     public static IServiceCollection AddLiquidParserTag<T>(this IServiceCollection services, string tagName)
             where T : class, ILiquidParserTag
     {
-        services.AddScoped<T>();
         services.AddScoped<ILiquidParserTag, T>();
         services.AddKeyedScoped<ILiquidParserTag, T>(tagName);
 

--- a/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Liquid/LiquidServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ public static class LiquidServiceCollectionExtensions
     {
         services.AddScoped<T>();
         services.AddScoped<ILiquidParserTag, T>();
-        services.AddKeyedScoped<ILiquidParserTag>(tagName);
+        services.AddKeyedScoped<ILiquidParserTag, T>(tagName);
 
         return services.Configure<LiquidViewOptions>(options =>
         {

--- a/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
@@ -24,31 +24,31 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18288" />
+    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18305" />
   </ItemGroup>
 
   <!-- Necessary so tag helpers will work in the projects depending on this. -->
   <ItemGroup>
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18288" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18305" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
@@ -24,31 +24,31 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18312" />
   </ItemGroup>
 
   <!-- Necessary so tag helpers will work in the projects depending on this. -->
   <ItemGroup>
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18312" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
@@ -24,31 +24,31 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18309" />
   </ItemGroup>
 
   <!-- Necessary so tag helpers will work in the projects depending on this. -->
   <ItemGroup>
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18309" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
@@ -24,31 +24,31 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18315" />
   </ItemGroup>
 
   <!-- Necessary so tag helpers will work in the projects depending on this. -->
   <ItemGroup>
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18315" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj
@@ -24,31 +24,31 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Alias" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Email.Abstractions" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.FileStorage.Abstractions" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Html" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Infrastructure" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Markdown" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Media.Core" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Queries" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Settings" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Setup.Abstractions" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Taxonomies" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Themes" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Title" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Users.Core" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.0.0-preview-18313" />
   </ItemGroup>
 
   <!-- Necessary so tag helpers will work in the projects depending on this. -->
   <ItemGroup>
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="2.0.0-preview-18313" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Shapes/ShapeExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Shapes/ShapeExtensions.cs
@@ -123,5 +123,5 @@ public static class ShapeExtensions
     /// Adds the warning to the screen which says "The current tenant will be reloaded when the settings are saved.".
     /// </summary>
     public static void AddTenantReloadWarning(this IShape shape) =>
-        shape.Metadata.Wrappers.Add("Settings_Wrapper__General");
+        shape.Metadata.Wrappers.Add("Settings_Wrapper__Reload");
 }

--- a/Lombiq.HelpfulLibraries.OrchardCore/TagHelpers/ShapeTagHelperBase.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/TagHelpers/ShapeTagHelperBase.cs
@@ -10,8 +10,8 @@ namespace Lombiq.HelpfulLibraries.OrchardCore.TagHelpers;
 /// </summary>
 public abstract class ShapeTagHelperBase<TModel> : TagHelper
 {
-    private readonly IDisplayHelper _displayHelper;
-    private readonly IShapeFactory _shapeFactory;
+    protected readonly IDisplayHelper _displayHelper;
+    protected readonly IShapeFactory _shapeFactory;
 
     /// <summary>
     /// Gets the type name of the shape to be displayed. If it returns <see langword="null"/>, the then <see

--- a/Lombiq.HelpfulLibraries.OrchardCore/TagHelpers/ShapeTagHelperBase.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/TagHelpers/ShapeTagHelperBase.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using OrchardCore.DisplayManagement;
+using System;
+using System.Threading.Tasks;
+
+namespace Lombiq.HelpfulLibraries.OrchardCore.TagHelpers;
+
+/// <summary>
+/// A base class for tag helpers that return a shape.
+/// </summary>
+public abstract class ShapeTagHelperBase<TModel> : TagHelper
+{
+    private readonly IDisplayHelper _displayHelper;
+    private readonly IShapeFactory _shapeFactory;
+
+    /// <summary>
+    /// Gets the type name of the shape to be displayed. If it returns <see langword="null"/>, the then <see
+    /// cref="GetShapeTypeAsync"/> is evaluated instead.
+    /// </summary>
+    protected abstract string ShapeType { get; }
+
+    protected ShapeTagHelperBase(IDisplayHelper displayHelper, IShapeFactory shapeFactory)
+    {
+        _displayHelper = displayHelper;
+        _shapeFactory = shapeFactory;
+    }
+
+    /// <summary>
+    /// Returns the view-model to be used when displaying the shape.
+    /// </summary>
+    protected abstract ValueTask<TModel> GetViewModelAsync(TagHelperContext context, TagHelperOutput output);
+
+    /// <summary>
+    /// If <see cref="ShapeType"/> is <see langword="null"/>, this method is evaluated to calculate the shape type.
+    /// </summary>
+    protected virtual ValueTask<string> GetShapeTypeAsync(TagHelperContext context, TagHelperOutput output) =>
+        throw new NotSupportedException(
+            $"Set {nameof(ShapeType)} to not null or implement {nameof(GetShapeTypeAsync)} in the derived type.");
+
+    /// <summary>
+    /// Optional tasks once the <paramref name="output"/>'s tag is disabled and the <see
+    /// cref="TagHelperOutput.PostContent"/> is already set to the rendered shape.
+    /// </summary>
+    protected virtual ValueTask PostProcessAsync(TagHelperContext context, TagHelperOutput output) =>
+        ValueTask.CompletedTask;
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var shape = await _shapeFactory.CreateAsync(
+            ShapeType ?? await GetShapeTypeAsync(context, output),
+            await GetViewModelAsync(context, output));
+        var content = await _displayHelper.ShapeExecuteAsync(shape);
+
+        output.TagName = null;
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.PostContent.SetHtmlContent(content);
+        await PostProcessAsync(context, output);
+    }
+}

--- a/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
+++ b/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18313" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18315" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18315" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
+++ b/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18288" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18288" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18305" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
+++ b/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18305" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18305" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18309" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
+++ b/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18312" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18313" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18313" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
+++ b/Lombiq.HelpfulLibraries.Samples/Lombiq.HelpfulLibraries.Samples.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18309" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18309" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="2.0.0-preview-18312" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="2.0.0-preview-18312" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[NEST-536](https://lombiq.atlassian.net/browse/NEST-536)
Make it easier to add Liquid `{% tags %}` and custom shape-based Razor tag helpers.

[NEST-536]: https://lombiq.atlassian.net/browse/NEST-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ