### PR TITLE
LMBQ-385: Fixing that reCAPTCHA also needs google.com in the frame-ancestors CSP header

### DIFF
--- a/Lombiq.HelpfulLibraries.OrchardCore/Security/ReCaptchaContentSecurityPolicyProvider.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Security/ReCaptchaContentSecurityPolicyProvider.cs
@@ -19,6 +19,7 @@ internal sealed class ReCaptchaContentSecurityPolicyProvider : IContentSecurityP
         {
             CspHelper.MergeValues(securityPolicies, ScriptSrc, "www.google.com", "www.gstatic.com");
             CspHelper.MergeValues(securityPolicies, FrameSrc, "www.google.com");
+            CspHelper.MergeValues(securityPolicies, FrameAncestors, "www.google.com");
         }
     }
 }

--- a/Lombiq.HelpfulLibraries.OrchardCore/Security/ReCaptchaContentSecurityPolicyProvider.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Security/ReCaptchaContentSecurityPolicyProvider.cs
@@ -17,9 +17,11 @@ internal sealed class ReCaptchaContentSecurityPolicyProvider : IContentSecurityP
 
         if (await shellFeaturesManager.IsFeatureEnabledAsync("OrchardCore.ReCaptcha"))
         {
-            CspHelper.MergeValues(securityPolicies, ScriptSrc, "www.google.com", "www.gstatic.com");
-            CspHelper.MergeValues(securityPolicies, FrameSrc, "www.google.com");
-            CspHelper.MergeValues(securityPolicies, FrameAncestors, "www.google.com");
+            const string googleDotCom = "www.google.com";
+
+            CspHelper.MergeValues(securityPolicies, ScriptSrc, googleDotCom, "www.gstatic.com");
+            CspHelper.MergeValues(securityPolicies, FrameSrc, googleDotCom);
+            CspHelper.MergeValues(securityPolicies, FrameAncestors, googleDotCom);
         }
     }
 }


### PR DESCRIPTION
[LMBQ-385](https://lombiq.atlassian.net/browse/LMBQ-385)

[LMBQ-385]: https://lombiq.atlassian.net/browse/LMBQ-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ