### PR TITLE
OSOE-1105: Adding the more useful DebugInformation to Nest response failures

### DIFF
--- a/Lombiq.HelpfulLibraries.OrchardCore/Elasticsearch/ResponseExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Elasticsearch/ResponseExtensions.cs
@@ -10,7 +10,7 @@ public static class ResponseExtensions
         if (response.IsValid) return response;
 
         if (!string.IsNullOrWhiteSpace(message)) message = $" ({message.Trim()})";
-        var error = $"Elasticsearch operation failed{message}. {response}";
+        var error = $"Elasticsearch operation failed{message}. {response.DebugInformation}";
         throw new InvalidOperationException(error);
     }
 }


### PR DESCRIPTION
[OSOE-1105](https://lombiq.atlassian.net/browse/OSOE-1105)

[OSOE-1105]: https://lombiq.atlassian.net/browse/OSOE-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ