### PR TITLE
OSOE-1212: Update dependency System.Linq.Async to v7 and fixing WhereAwait() deprecation

### DIFF
--- a/Lombiq.HelpfulLibraries.Common/Extensions/EnumerableExtensions.cs
+++ b/Lombiq.HelpfulLibraries.Common/Extensions/EnumerableExtensions.cs
@@ -307,7 +307,8 @@ public static class EnumerableExtensions
     public static IAsyncEnumerable<T> WhereNotAsync<T>(
         this IAsyncEnumerable<T> collection,
         Func<T, Task<bool>> negativePredicate) =>
-        collection.WhereAwait(async value => !await negativePredicate(value));
+        collection.Where(
+            async (value, _) => !await negativePredicate(value));
 
     /// <summary>
     /// Returns <paramref name="collection"/> if it's not <see langword="null"/>, otherwise <see

--- a/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
+++ b/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
[OSOE-1212](https://lombiq.atlassian.net/browse/OSOE-1212)

[OSOE-1212]: https://lombiq.atlassian.net/browse/OSOE-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ