### PR TITLE
OSOE-1036: Use `ISession.FlushAsync()` instead of `SaveChangesAsync()` in Lombiq.HelpfulLibraries

### DIFF
--- a/Lombiq.HelpfulLibraries.Tests/UnitTests/Services/ManualConnectingIndexServiceFixture.cs
+++ b/Lombiq.HelpfulLibraries.Tests/UnitTests/Services/ManualConnectingIndexServiceFixture.cs
@@ -46,7 +46,7 @@ public sealed class ManualConnectingIndexServiceFixture : IDisposable
 
         await using var session = Store.CreateSession();
         await action(session);
-        await session.SaveChangesAsync();
+        await session.FlushAsync();
     }
 
     // We could have a
@@ -91,10 +91,8 @@ public sealed class ManualConnectingIndexServiceFixture : IDisposable
             await connection.CloseAsync();
         }
 
-        await SessionAsync(async session =>
-        {
-            foreach (var document in Documents) await session.SaveAsync(document);
-        });
+        await using var session = Store.CreateSession();
+        foreach (var document in Documents) await session.SaveAsync(document);
 
         var manualConnectingIndexService = new ManualConnectingIndexService<TestDocumentIndex>(
             dbAccessor,
@@ -110,10 +108,10 @@ public sealed class ManualConnectingIndexServiceFixture : IDisposable
                     CultureInfo.InvariantCulture),
             };
 
-            await SessionAsync(session => manualConnectingIndexService.AddAsync(index, session, i + 1));
+            await manualConnectingIndexService.AddAsync(index, session, i + 1);
         }
 
-        await SessionAsync(session =>
-            manualConnectingIndexService.RemoveAsync(nameof(TestDocumentIndex.Number), 6, session));
+        await manualConnectingIndexService.RemoveAsync(nameof(TestDocumentIndex.Number), 6, session);
+        await session.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
[OSOE-1036](https://lombiq.atlassian.net/browse/OSOE-1036)
Fixes #319

[OSOE-1036]: https://lombiq.atlassian.net/browse/OSOE-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ