### PR TITLE
OSOE-1254: Update dependencies: linq2db 6.1.0 → 6.2.1, fix MA0127 warning

### DIFF
--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="linq2db" Version="6.1.0" />
+    <PackageReference Include="linq2db" Version="6.2.1" />
     <PackageReference Include="OrchardCore.Data.YesSql" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/Lombiq.HelpfulLibraries.OrchardCore/ResourceManagement/ResourceFilterBuilder.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/ResourceManagement/ResourceFilterBuilder.cs
@@ -164,7 +164,7 @@ public class ResourceFilterBuilder
             }
 
             var session = context.RequestServices.GetRequiredService<ISession>();
-            var query = displayType is "Edit" ?
+            var query = displayType.EqualsOrdinalIgnoreCase("Edit") ?
                 // We check for both published and draft content items.
                 session.QueryIndex<ContentItemIndex>(index => index.Published || (index.Latest && !index.Published))
                 : session.QueryContentItemIndex(PublicationStatus.Published);


### PR DESCRIPTION
[OSOE-1254](https://lombiq.atlassian.net/browse/OSOE-1254): Update linq2db and fix MA0127 analyzer warning.

- linq2db 6.1.0 → 6.2.1
- Fix MA0127 in ResourceFilterBuilder.cs: use EqualsOrdinalIgnoreCase

[OSOE-1254]: https://lombiq.atlassian.net/browse/OSOE-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ