### PR TITLE
NEST-668: Handling null Headers in SimpleTextResponse after the Refit v11 upgrade

### DIFF
--- a/Lombiq.HelpfulLibraries.Refit/Models/SimpleTextResponse.cs
+++ b/Lombiq.HelpfulLibraries.Refit/Models/SimpleTextResponse.cs
@@ -51,7 +51,7 @@ public class SimpleTextResponse
         Headers = response.Headers?.ToDictionary<KeyValuePair<string, IEnumerable<string>>, string, string?>(
             header => header.Key,
             header => header.Value.FirstOrDefault())
-            ?? new Dictionary<string, string?>();
+            ?? [];
         IsOk = response.Error == null && response.StatusCode == HttpStatusCode.OK;
         StatusCode = response.StatusCode;
         Error = response.Error;

--- a/Lombiq.HelpfulLibraries.Refit/Models/SimpleTextResponse.cs
+++ b/Lombiq.HelpfulLibraries.Refit/Models/SimpleTextResponse.cs
@@ -48,9 +48,10 @@ public class SimpleTextResponse
     internal SimpleTextResponse(IApiResponse<string> response)
     {
         Content = response.Content;
-        Headers = response.Headers.ToDictionary<KeyValuePair<string, IEnumerable<string>>, string, string?>(
+        Headers = response.Headers?.ToDictionary<KeyValuePair<string, IEnumerable<string>>, string, string?>(
             header => header.Key,
-            header => header.Value.First());
+            header => header.Value.FirstOrDefault())
+            ?? new Dictionary<string, string?>();
         IsOk = response.Error == null && response.StatusCode == HttpStatusCode.OK;
         StatusCode = response.StatusCode;
         Error = response.Error;


### PR DESCRIPTION
[NEST-668](https://lombiq.atlassian.net/browse/NEST-668)

[NEST-668]: https://lombiq.atlassian.net/browse/NEST-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ