### PR TITLE
OSOE-1311: Update dependencies: AngleSharp 1.6.0 -> 1.7.0, Microsoft.Extensions.* -> 10.0.11

### DIFF
--- a/Lombiq.HelpfulLibraries.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/Lombiq.HelpfulLibraries.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -1,7 +1,7 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -32,8 +32,11 @@ public static class HttpRequestExtensions
         if (queryString.StartsWith('?')) queryString = queryString[1..];
 
         var pageQuery = string.IsNullOrEmpty(queryString)
-            ? StringHelper.CreateInvariant($"{key}={value}")
-            : StringHelper.CreateInvariant($"&{key}={value}");
+            // MA0185 doesn't apply: value is an arbitrary object that can hold culture-sensitive data at runtime.
+#pragma warning disable MA0185
+            ? string.Create(CultureInfo.InvariantCulture, $"{key}={value}")
+            : string.Create(CultureInfo.InvariantCulture, $"&{key}={value}");
+#pragma warning restore MA0185
         return $"{request.PathBase}{request.Path}?{queryString}{pageQuery}";
     }
 

--- a/Lombiq.HelpfulLibraries.Common/Extensions/EnumExtensions.cs
+++ b/Lombiq.HelpfulLibraries.Common/Extensions/EnumExtensions.cs
@@ -1,5 +1,5 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Reflection;
 
 namespace System;
@@ -13,7 +13,7 @@ public static class EnumExtensions
     /// </summary>
     public static InvalidOperationException UnknownEnumException<T>(this T other)
         where T : Enum =>
-        new(StringHelper.CreateInvariant($"Unknown {other.GetType().Name}: '{other}'"));
+        new(string.Create(CultureInfo.InvariantCulture, $"Unknown {other.GetType().Name}: '{other}'"));
 
     /// <summary>
     /// Attempts to retrieve an <see cref="Enum"/> object's <see cref="DisplayAttribute.Name"/> value.

--- a/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
+++ b/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
   </ItemGroup>
 
   <Import Condition="'$(NuGetBuild)' != 'true'" Project="../../../Utilities/Lombiq.MSBuild.Targets/Lombiq.MSBuild.Library.Sdk/Sdk/Import.targets" />

--- a/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
+++ b/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.6.0" />
+    <PackageReference Include="AngleSharp" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
   </ItemGroup>

--- a/Lombiq.HelpfulLibraries.Common/Utilities/StringHelper.cs
+++ b/Lombiq.HelpfulLibraries.Common/Utilities/StringHelper.cs
@@ -46,7 +46,7 @@ public static class StringHelper
     /// <remarks>
     /// <para>
     /// This doesn't actually work: the interpolation holes are formatted using the current culture at the call site
-    /// before this method ever runs, since there's no <see cref="System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/>
+    /// before this method ever runs, since there's no <see cref="InterpolatedStringHandlerArgumentAttribute"/>
     /// wiring to pass the invariant culture into the handler's construction. Use <c>string.Create(CultureInfo.InvariantCulture,
     /// $"...")</c> directly instead. See <see
     /// href="https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245"/> for details.

--- a/Lombiq.HelpfulLibraries.Common/Utilities/StringHelper.cs
+++ b/Lombiq.HelpfulLibraries.Common/Utilities/StringHelper.cs
@@ -43,6 +43,18 @@ public static class StringHelper
     /// Creates a <see langword="string"/> from an interpolated string with the invariant culture. This prevents
     /// culture-sensitive formatting of interpolated values.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This doesn't actually work: the interpolation holes are formatted using the current culture at the call site
+    /// before this method ever runs, since there's no <see cref="System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/>
+    /// wiring to pass the invariant culture into the handler's construction. Use <c>string.Create(CultureInfo.InvariantCulture,
+    /// $"...")</c> directly instead. See <see
+    /// href="https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245"/> for details.
+    /// </para>
+    /// </remarks>
+    [Obsolete("This doesn't actually apply the invariant culture to interpolation holes. Use " +
+        "string.Create(CultureInfo.InvariantCulture, $\"...\") directly instead. See " +
+        "https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245.")]
     public static string CreateInvariant(this DefaultInterpolatedStringHandler value) =>
         string.Create(CultureInfo.InvariantCulture, ref value);
 

--- a/Lombiq.HelpfulLibraries.OrchardCore.Testing/Lombiq.HelpfulLibraries.OrchardCore.Testing.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore.Testing/Lombiq.HelpfulLibraries.OrchardCore.Testing.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore.Testing/Lombiq.HelpfulLibraries.OrchardCore.Testing.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore.Testing/Lombiq.HelpfulLibraries.OrchardCore.Testing.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Excluding analyzers: the Moq.AutoMocker.Generators analyzer requires a newer Roslyn than the NuGet packaging
-         pipeline's compiler and isn't used by this project anyway. -->
-    <PackageReference Include="Moq.AutoMock" Version="4.0.3" ExcludeAssets="analyzers" />
+    <!-- Kept on 4.0.2: 4.0.3's Moq.AutoMocker.Generators analyzer requires a newer Roslyn than the NuGet packaging
+         pipeline's compiler supports, breaking "dotnet pack" with CS9057. Not used by this project anyway. -->
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore.Testing/Lombiq.HelpfulLibraries.OrchardCore.Testing.csproj
+++ b/Lombiq.HelpfulLibraries.OrchardCore.Testing/Lombiq.HelpfulLibraries.OrchardCore.Testing.csproj
@@ -17,7 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq.AutoMock" Version="4.0.3" />
+    <!-- Excluding analyzers: the Moq.AutoMocker.Generators analyzer requires a newer Roslyn than the NuGet packaging
+         pipeline's compiler and isn't used by this project anyway. -->
+    <PackageReference Include="Moq.AutoMock" Version="4.0.3" ExcludeAssets="analyzers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Mvc/ShapeResultExtensions.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Mvc/ShapeResultExtensions.cs
@@ -1,5 +1,5 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.HelpfulLibraries.OrchardCore.Contents;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace OrchardCore.DisplayManagement.Views;
@@ -18,7 +18,7 @@ public static class ShapeResultExtensions
         string name,
         double priority,
         string placement = CommonLocationNames.Parts) =>
-        shapeResult.Location(StringHelper.CreateInvariant($"{placement}#{name}:{priority}"));
+        shapeResult.Location(string.Create(CultureInfo.InvariantCulture, $"{placement}#{name}:{priority}"));
 
     /// <summary>
     /// The shape will only be rendered if <paramref name="condition"/> is <see langword="true"/>. This is a shortcut
@@ -32,7 +32,7 @@ public static class ShapeResultExtensions
     /// </summary>
     public static ShapeResult PlaceInZone(this ShapeResult shapeResult, string zoneName, double? priority = null) =>
         shapeResult.Location(priority is { } number
-            ? StringHelper.CreateInvariant($"{zoneName}:{number}")
+            ? string.Create(CultureInfo.InvariantCulture, $"{zoneName}:{number}")
             : zoneName);
 
     /// <summary>

--- a/Lombiq.HelpfulLibraries.OrchardCore/Mvc/WidgetFilterBase.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Mvc/WidgetFilterBase.cs
@@ -1,4 +1,3 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.HelpfulLibraries.OrchardCore.Contents;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -78,8 +77,8 @@ public abstract class WidgetFilterBase<TViewModel> : IAsyncResultFilter
 
         if (AdminOnly && FrontEndOnly)
         {
-            throw new InvalidOperationException(StringHelper.CreateInvariant(
-                $"You must not set both {nameof(AdminOnly)} and {nameof(FrontEndOnly)} to true!"));
+            throw new InvalidOperationException(
+                $"You must not set both {nameof(AdminOnly)} and {nameof(FrontEndOnly)} to true!");
         }
 
         var isAdmin = AdminAttribute.IsApplied(httpContext);

--- a/Lombiq.HelpfulLibraries.OrchardCore/Navigation/NavigationProviderBase.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/Navigation/NavigationProviderBase.cs
@@ -1,4 +1,3 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Navigation;
@@ -42,6 +41,6 @@ public abstract class NavigationProviderBase : INavigationProvider
     }
 
     protected virtual void Build(NavigationBuilder builder) =>
-        throw new NotSupportedException(StringHelper.CreateInvariant(
-            $"Override either {nameof(Build)} or {nameof(BuildAsync)}! Note that {nameof(BuildAsync)} takes precedence in execution."));
+        throw new NotSupportedException(
+            $"Override either {nameof(Build)} or {nameof(BuildAsync)}! Note that {nameof(BuildAsync)} takes precedence in execution.");
 }

--- a/Lombiq.HelpfulLibraries.Refit/CompatibilitySuppressions.xml
+++ b/Lombiq.HelpfulLibraries.Refit/CompatibilitySuppressions.xml
@@ -1,8 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>PKV006</DiagnosticId>
-    <Target>net8.0</Target>
-  </Suppression>
-</Suppressions>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />

--- a/Lombiq.HelpfulLibraries.RestEase/Lombiq.HelpfulLibraries.RestEase.csproj
+++ b/Lombiq.HelpfulLibraries.RestEase/Lombiq.HelpfulLibraries.RestEase.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageReference Include="RestEase" Version="1.6.4" />
     <PackageReference Include="RestEase.SourceGenerator" Version="1.6.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Lombiq.HelpfulLibraries.Samples/Controllers/LinqToDbSamplesController.cs
+++ b/Lombiq.HelpfulLibraries.Samples/Controllers/LinqToDbSamplesController.cs
@@ -1,12 +1,12 @@
 using LinqToDB;
 using LinqToDB.Async;
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.HelpfulLibraries.LinqToDb;
 using Lombiq.HelpfulLibraries.Samples.Models;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Autoroute.Core.Indexes;
 using OrchardCore.ContentManagement.Records;
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using YesSql;
@@ -75,7 +75,8 @@ public sealed class LinqToDbSamplesController : Controller
             .Where(record => record.Author == "Jules Verne")
             .DeleteAsync(HttpContext.RequestAborted));
 
-        return Ok(StringHelper.CreateInvariant(
+        return Ok(string.Create(
+            CultureInfo.InvariantCulture,
             $"Inserted: {insertedCount}, modified: {modifiedCount}, deleted: {deletedCount}."));
     }
 }

--- a/Lombiq.HelpfulLibraries.SourceGenerators/Lombiq.HelpfulLibraries.SourceGenerators.csproj
+++ b/Lombiq.HelpfulLibraries.SourceGenerators/Lombiq.HelpfulLibraries.SourceGenerators.csproj
@@ -41,7 +41,7 @@
     <ItemGroup>
         <!-- Take a private dependency on with (PrivateAssets=all) Consumers of this generator will not reference it.
              Set GeneratePathProperty=true so we can reference the binaries -->
-        <PackageReference Include="System.Text.Json" Version="10.0.10" PrivateAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="System.Text.Json" Version="10.0.11" PrivateAssets="all" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" GeneratePathProperty="true">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,16 @@
             enabled: false,
         },
         {
+            // Moq.AutoMock ships the Moq.AutoMocker.Generators analyzer, which can require a newer Roslyn than the
+            // NuGet packaging pipeline's compiler, causing the same kind of CS9057 error as Microsoft.CodeAnalysis.CSharp
+            // above (see OSOE-1311). So, we need to update it manually and verify the "Validate NuGet Publish" workflow
+            // still passes.
+            matchPackageNames: [
+                'Moq.AutoMock',
+            ],
+            enabled: false,
+        },
+        {
             groupName: 'Microsoft.Extensions',
             matchPackageNames: [
                 'Microsoft.Extensions.*',


### PR DESCRIPTION
Renovate dependency integration for OSOE-1311.

- Merged `renovate/non-breaking-dependency-versions` (AngleSharp 1.6.0 -> 1.7.0) and `renovate/microsoft.extensions` (Microsoft.Extensions.Caching.Memory / Configuration.Binder -> 10.0.11).
- Excluded Moq.AutoMock 4.0.3 from `Lombiq.HelpfulLibraries.OrchardCore.Testing` (kept at 4.0.2) since its analyzer breaks the NuGet packaging build with CS9057.
- Fixed a stale `CompatibilitySuppressions.xml` entry for `Lombiq.HelpfulLibraries.Refit` (unrelated pre-existing issue on `dev`).
- Marked `StringHelper.CreateInvariant` obsolete and replaced its usages with `string.Create(CultureInfo.InvariantCulture, ...)`, since the former doesn't actually apply the invariant culture to interpolation holes; see https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245.
