### PR TITLE
OSOE-1312: Update dependencies: Refit.HttpClientFactory 14.0.1 → 15.2.0, CliWrap, AngleSharp, linq2db

### DIFF
--- a/Lombiq.HelpfulLibraries.Cli/Lombiq.HelpfulLibraries.Cli.csproj
+++ b/Lombiq.HelpfulLibraries.Cli/Lombiq.HelpfulLibraries.Cli.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.10.4" />
+    <PackageReference Include="CliWrap" Version="3.10.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
+++ b/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.7.0" />
+    <PackageReference Include="AngleSharp" Version="1.7.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
   </ItemGroup>

--- a/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
+++ b/Lombiq.HelpfulLibraries.LinqToDb/Lombiq.HelpfulLibraries.LinqToDb.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="linq2db" Version="6.3.0" />
+    <PackageReference Include="linq2db" Version="6.4.0" />
     <PackageReference Include="OrchardCore.Data.YesSql" Version="$(OrchardCoreVersion)" />
   </ItemGroup>
 

--- a/Lombiq.HelpfulLibraries.Refit/Lombiq.HelpfulLibraries.Refit.csproj
+++ b/Lombiq.HelpfulLibraries.Refit/Lombiq.HelpfulLibraries.Refit.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="15.2.0" />
   </ItemGroup>
 
   <Import Condition="'$(NuGetBuild)' != 'true'" Project="../../../Utilities/Lombiq.MSBuild.Targets/Lombiq.MSBuild.Library.Sdk/Sdk/Import.targets" />


### PR DESCRIPTION
Part of [OSOE-1312](https://lombiq.atlassian.net/browse/OSOE-1312).

Merges:
- #415 `renovate/major-refit-monorepo` — Refit.HttpClientFactory 14.0.1 → 15.2.0.
- #412 `renovate/non-breaking-dependency-versions` — CliWrap 3.10.4 → 3.10.5, AngleSharp 1.7.0 → 1.7.2, linq2db 6.3.0 → 6.4.0.


[OSOE-1312]: https://lombiq.atlassian.net/browse/OSOE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ