### PR TITLE
OSOE-1312: Simplify string.Create with only culture-invariant parameters (MA0185)

### DIFF
--- a/Lombiq.HelpfulLibraries.Common/Extensions/EnumExtensions.cs
+++ b/Lombiq.HelpfulLibraries.Common/Extensions/EnumExtensions.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using System.Reflection;
 
 namespace System;
@@ -13,7 +12,7 @@ public static class EnumExtensions
     /// </summary>
     public static InvalidOperationException UnknownEnumException<T>(this T other)
         where T : Enum =>
-        new(string.Create(CultureInfo.InvariantCulture, $"Unknown {other.GetType().Name}: '{other}'"));
+        new($"Unknown {other.GetType().Name}: '{other}'");
 
     /// <summary>
     /// Attempts to retrieve an <see cref="Enum"/> object's <see cref="DisplayAttribute.Name"/> value.


### PR DESCRIPTION
Part of [OSOE-1312](https://lombiq.atlassian.net/browse/OSOE-1312) (follow-up fix).

Fixes `MA0185` (\"Simplify string.Create when all parameters are culture invariant\") in `EnumExtensions.UnknownEnumException`, flagged by CI's `-warnaserror` after the Meziantou.Analyzer bump merged in #416. Both interpolated values (`other.GetType().Name` and the `Enum` value itself) are culture-invariant, so `string.Create(CultureInfo.InvariantCulture, ...)` is unnecessary here.


[OSOE-1312]: https://lombiq.atlassian.net/browse/OSOE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ