### PR TITLE
OSOE-1316: Update dependencies: AngleSharp 1.7.3

### DIFF
--- a/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
+++ b/Lombiq.HelpfulLibraries.Common/Lombiq.HelpfulLibraries.Common.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.7.2" />
+    <PackageReference Include="AngleSharp" Version="1.7.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
   </ItemGroup>

--- a/Lombiq.HelpfulLibraries.OrchardCore/GraphQL/TotalOfContentTypeBuilder.cs
+++ b/Lombiq.HelpfulLibraries.OrchardCore/GraphQL/TotalOfContentTypeBuilder.cs
@@ -44,7 +44,7 @@ public class TotalOfContentTypeBuilder : IContentTypeBuilder
                 index.Published &&
                 index.Latest &&
                 index.ContentType == name)
-                .CountAsync();
+                .CountAsync(context.CancellationToken);
         });
     }
 


### PR DESCRIPTION
Merges the following open Renovate PRs into a single branch, plus a manual fix:
- #419 Update dependency AngleSharp to 1.7.3
- Fix MA0040 (missing CancellationToken overload) in TotalOfContentTypeBuilder.cs, surfaced by the Meziantou.Analyzer bump in Lombiq.Analyzers.

Part of [OSOE-1316](https://lombiq.atlassian.net/browse/OSOE-1316).


[OSOE-1316]: https://lombiq.atlassian.net/browse/OSOE-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ